### PR TITLE
README.md.j2 correct replacement of "role-enable" variable

### DIFF
--- a/README.md.j2
+++ b/README.md.j2
@@ -16,7 +16,7 @@ Variables for this
 
 | variable | default value in defaults/main.yml | description |
 | -------- | ---------------------------------- | ----------- |
-| {{ role_name|replace('ansible-role-', 'role_') }}_enabled | false | determine whether role is enabled (true) or not (false) |
+| {{ role_name | replace('ansible-role-', 'role_') | replace('-','_') }}_enabled | false | determine whether role is enabled (true) or not (false) |
 
 ## Dependencies
 


### PR DESCRIPTION
Hello jam82,
In the Readme there was just another "role-enable-variable" to fix the renaming.